### PR TITLE
Fixed .NET 7 test action

### DIFF
--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -21,8 +21,6 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-      COVER_REPORT_FILE: "~/test/coverage.xml"
   steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -66,7 +66,7 @@ runs:
         done
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1.7
+      uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{inputs.awsAccessKeyId}}
         aws-secret-access-key: ${{inputs.awsAccessKeySecret}}

--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -66,7 +66,7 @@ runs:
         done
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1.7
       with:
         aws-access-key-id: ${{inputs.awsAccessKeyId}}
         aws-secret-access-key: ${{inputs.awsAccessKeySecret}}


### PR DESCRIPTION
Removed unused env variable, that can't be used in that way with "composite" runs.