### PR TITLE
Added support to generage nuget packages using the new folder structure

### DIFF
--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -82,15 +82,7 @@ runs:
             -p:SourceRevisionId=${{steps.bumpVersion.outputs.productVersion}} \
             --no-restore
         done
-        
-    # - name: Package
-    #   shell: bash
-    #   run: |
-    #     for f in $(find . -name "*.sln"); do echo "packaging solution $f" && \
-    #       dotnet pack $f \
-    #         --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
-    #         --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
-    #     done
+
     - name: Package
       shell: bash
       run: |

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -94,8 +94,7 @@ runs:
     - name: Package
       shell: bash
       run: |
-        ls
-        for project in $(grep -rl 'Packable.Projects.props' src/**/*.csproj); do echo "packaging project $project" && \
+        for project in $(find ./src -name "*.csproj" -exec grep -rl "Packable.Projects.props" {} \;); do echo "packaging project $project" && \
           dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
         done

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -83,12 +83,20 @@ runs:
             --no-restore
         done
         
+    # - name: Package
+    #   shell: bash
+    #   run: |
+    #     for f in $(find . -name "*.sln"); do echo "packaging solution $f" && \
+    #       dotnet pack $f \
+    #         --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
+    #         --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
+    #     done
     - name: Package
       shell: bash
       run: |
-        for f in $(find . -name "*.sln"); do echo "packaging solution $f" && \
-          dotnet pack $f \
-            --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
+        packables=$(grep -rl '/Packable\.Projects\.props"' ./src/**/*.csproj)
+        for project in $packables; do echo "packaging project $project" && \
+          dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
         done
 

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -86,7 +86,7 @@ runs:
     - name: Package
       shell: bash
       run: |
-        packables=$(grep -rl '<Import Project="\.\.\/Packable\.Projects\.props" \/>' ./src/**/*.csproj)
+        packables=$(grep -rl '/Packable\.Projects\.props" \/>' ./src/**/*.csproj)
         for project in $packables; do echo "packaging project $project" && \
           dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -86,9 +86,9 @@ runs:
     - name: Package
       shell: bash
       run: |
-        packables=$(grep -rl '/Packable\.Projects\.props" \/>' ./src/**/*.csproj)
-        for project in $packables; do echo "packaging project $project" && \
-          dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
+        for f in $(find . -name "*.sln"); do echo "packaging solution $f" && \
+          dotnet pack $f \
+            --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
         done
 

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -94,7 +94,8 @@ runs:
     - name: Package
       shell: bash
       run: |
-        for project in $(grep -rl '/Packable\.Projects\.props"' src/**/*.csproj); do echo "packaging project $project" && \
+        ls
+        for project in $(grep -rl 'Packable.Projects.props' src/**/*.csproj); do echo "packaging project $project" && \
           dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
         done

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -94,8 +94,7 @@ runs:
     - name: Package
       shell: bash
       run: |
-        packables=$(grep -rl '/Packable\.Projects\.props"' ./src/**/*.csproj)
-        for project in $packables; do echo "packaging project $project" && \
+        for project in $(grep -rl '/Packable\.Projects\.props"' src/**/*.csproj); do echo "packaging project $project" && \
           dotnet pack $project --no-build --configuration ${{ steps.comp-mode.outputs.compilationMode }} \
             --output ./nuget/ -p:PackageVersion=${{steps.bumpVersion.outputs.fullVersion}} --include-symbols --include-source
         done

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        for f in ./src/*.sln; do echo "restoring solution $f" && \
+        for f in $(find . -name "*.sln"); do echo "restoring solution $f" && \
         dotnet restore $f
         done
 
@@ -75,7 +75,7 @@ runs:
     - name: Build
       shell: bash
       run: |
-        for f in ./src/*.sln; do echo "building solution $f" && \
+        for f in $(find . -name "*.sln"); do echo "building solution $f" && \
           dotnet build $f \
             --configuration ${{steps.comp-mode.outputs.compilationMode}} \
             -p:Version=${{steps.bumpVersion.outputs.assemblyVersion}} \


### PR DESCRIPTION
- Fixed to find sln files outside src folder (following the new project structure)
- Changed the way it searches for packable projects, because the double-asterisk wasn't working for multiple sub directories, like is built in the new solution folder structure