### PR TITLE
Removed commit sha from codacy report notification to make codacy search automatically for it

### DIFF
--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -92,6 +92,6 @@ runs:
       run: |
         for f in $(find ./TestResults -name "coverage.cobertura.xml"); do echo "sending coverage report $f" && \
             bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l csharp -r $f \
-                --partial --commit-uuid ${{github.sha}}; \
+                --partial; \
         done
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) final --commit-uuid ${{github.sha}}
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) final


### PR DESCRIPTION
Codacy can't find commit sha for test coverage reports via pull requests.

Tested in common repo: https://github.com/trakx/common/pull/119

![image](https://user-images.githubusercontent.com/6867927/221242774-f78b8c76-de54-443e-85ae-a324716e62c9.png)
