### PR TITLE
Upgrade configure-aws-credentials to v2, to stop 'set-output' warnings

### DIFF
--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -66,7 +66,7 @@ runs:
         done
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{inputs.awsAccessKeyId}}
         aws-secret-access-key: ${{inputs.awsAccessKeySecret}}


### PR DESCRIPTION
<https://github.com/aws-actions/configure-aws-credentials/issues/521#issuecomment-1457428308>