### PR TITLE
Upgrade `configure-aws-credentials` to v2, to stop `set-output` warnings

### DIFF
--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -92,6 +92,6 @@ runs:
       run: |
         for f in $(find ./TestResults -name "coverage.cobertura.xml"); do echo "sending coverage report $f" && \
             bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l csharp -r $f \
-                --partial --commit-uuid ${{github.sha}}; \
+                --partial; \
         done
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) final --commit-uuid ${{github.sha}}
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) final


### PR DESCRIPTION
https://github.com/aws-actions/configure-aws-credentials/issues/521#issuecomment-1457428308