### PR TITLE
Replace `set-output` commands in `publish-nuget`

### DIFF
--- a/get-tag/action.yml
+++ b/get-tag/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Get next or latest semver
       id: bumpSemver
-      uses: anothrNick/github-tag-action@1.39.0
+      uses: anothrNick/github-tag-action@1.62.0
       env:
         GITHUB_TOKEN: ${{inputs.githubToken}}
         DEFAULT_BUMP: ${{steps.bumpLevel.outputs.finalLevel}}

--- a/get-tag/action.yml
+++ b/get-tag/action.yml
@@ -30,7 +30,7 @@ runs:
         LEVEL="${{inputs.semverIncrementLevel}}"
         LEVEL=${LEVEL:-patch}
         echo "bump level set to $LEVEL"
-        echo '::set-output name=finalLevel::'$LEVEL
+        echo "finalLevel=$LEVEL" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get commit shortened commit hash
@@ -38,7 +38,7 @@ runs:
       id: shortHash
       run: |
         short_hash=$(git rev-parse --short "$GITHUB_SHA")
-        echo '::set-output name=shortHash::'$short_hash
+        echo "shortHash=$short_hash" >> $GITHUB_OUTPUT
 
     - name: Get next or latest semver
       id: bumpSemver
@@ -75,9 +75,9 @@ runs:
             PRODUCT_VERSION=${BRANCH_NAME}-${{github.run_number}}-${{steps.shortHash.outputs.shortHash}}
             FULL_VERSION=${SUBSTRING_LEFT_OF_DASH}-${PRODUCT_VERSION}
         fi
-        echo '::set-output name=assemblyVersion::'$SUBSTRING_LEFT_OF_DASH
-        echo '::set-output name=productVersion::'$PRODUCT_VERSION
-        echo '::set-output name=fullVersion::'$FULL_VERSION
+        echo "assemblyVersion=$SUBSTRING_LEFT_OF_DASH" >> $GITHUB_OUTPUT
+        echo "productVersion=$PRODUCT_VERSION" >> $GITHUB_OUTPUT
+        echo "fullVersion=$FULL_VERSION" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Print bumpSemver outputs

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -23,13 +23,6 @@ runs:
     - name: Checkout calling repo
       uses: actions/checkout@v3
 
-    - name: Checkout actions repo
-      uses: actions/checkout@v3
-      with:
-        repository: trakx/github-actions
-        path: github-actions
-        ref: master
-
     - name: Set compilation mode
       shell: bash
       id: comp-mode

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -39,7 +39,7 @@ runs:
         else
           COMP_MODE=Debug
         fi
-        echo '::set-output name=compilationMode::'$COMP_MODE
+        echo "compilationMode=$COMP_MODE" >> $GITHUB_OUTPUT
         echo "compilation mode set to ${{steps.comp-mode.outputs.compilationMode}}"
 
     - name: Bump version

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -16,12 +16,23 @@ inputs:
     description: "Level of the semver (major.minor.patch) to be increased to get the new package version."
     required: false
     default: "patch"
-
+  actionRef:
+    description: "Run actions from this ref. Default is master."
+    required: false
+    default: "master"
+    
 runs:
   using: "composite"
   steps:
     - name: Checkout calling repo
       uses: actions/checkout@v3
+
+    - name: Checkout actions repo
+      uses: actions/checkout@v3
+      with:
+        repository: trakx/github-actions
+        path: github-actions
+        ref: ${{ inputs.actionRef }}
 
     - name: Set compilation mode
       shell: bash

--- a/push-tag/action.yml
+++ b/push-tag/action.yml
@@ -32,7 +32,7 @@ runs:
           echo "tag $TAG already exists"
           FOUND="true"
         fi
-        echo '::set-output name=tag_exists::'$FOUND
+        echo "tag_exists=$FOUND" >> $GITHUB_OUTPUT
 
     - name: Push tag
       if: ${{ steps.exists.outputs.tag_exists == 'false' }}

--- a/push-tag/action.yml
+++ b/push-tag/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Push tag
       if: ${{ steps.exists.outputs.tag_exists == 'false' }}
-      uses: anothrNick/github-tag-action@1.39.0
+      uses: anothrNick/github-tag-action@1.62.0
       env:
         GITHUB_TOKEN: ${{inputs.githubToken}}
         DRY_RUN: 'false'


### PR DESCRIPTION
Replaced some `set-output` commands in our files.

We are using anothrNick/github-tag-action to v1.39.0, over a year old.
It also throws the `set-output` warnings that Github will soon start erroring on.

In this PR, the version is bumped to v1.62.0.
Release notes: <https://github.com/anothrNick/github-tag-action/releases>