### PR TITLE
Bump `setup-dotnet` action to v3

### DIFF
--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -53,7 +53,7 @@ runs:
         semverIncrementLevel: ${{ inputs.semverIncrementLevel }}
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.x
 


### PR DESCRIPTION
This bump has been tested and working in `shrimpy-api-client`:
<https://github.com/trakx/shrimpy-api-client/actions/runs/4753109188/workflow#L66>
<https://github.com/trakx/shrimpy-api-client/actions/runs/4753109188/jobs/8444314952>

