### PR TITLE
Feature/add deploy events tkx 865

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -50,12 +50,12 @@ runs:
         token: '${{ inputs.githubToken }}'
         environment: ${{ inputs.environment}}
         payload: |
-          '{ 
+            { 
                 "artifactName" : "${{ inputs.artifact-name }}",
                 "deploymentType" : "${{ inputs.type }}", 
                 "service" : "${{ inputs.service }}",
                 "tag" : "${{ inputs.tag }}"
-            }'
+            }
 
     ###### Deployment types switch ######
 

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -2,6 +2,9 @@ name: "Deploy"
 description: "Create a GitHub deployments, attempts to deploy and update deployment status."
 
 inputs:
+  githubToken:
+    description: GitHub token
+    required: true
   environment:
     description: "The environment targeted for the deployment"
     required: true
@@ -32,7 +35,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.environment }}" != "production" 
-          && "${{ inputs.environment }}" != "stage" 
+          && "${{ inputs.environment }}" != "staging" 
           && "${{ inputs.environment }}" != "development" ]]; then
             echo "Unsupported environment: ${{ inputs.environment }}"
           exit 1

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -25,12 +25,9 @@ inputs:
 
 runs:
 
-  using: composite
+  using: "composite"
 
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
     - name: Check inputs
       shell: bash
       run: |

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -51,7 +51,7 @@ runs:
       id: create-deployment
       with:
         token: '${{ github.token }}'
-        environment: ${{inputs.environment}}
+        environment: ${{ inputs.environment }}
         payload: |
           '{ 
                 "artifactName" : "${{ inputs.artifact-name }}",
@@ -64,10 +64,9 @@ runs:
 
     ###### Kubernetes deployments ######
 
-      
     - name: Install Kubernetes & Kustomize
       #Since github runners working in Docker-in-Docker mode we need this workaround
-      if: $ {{ inputs.type == 'kubernetes' }}
+      if: ${{ inputs.type == 'kubernetes' }}
       shell: bash
       run: |
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
@@ -76,7 +75,7 @@ runs:
         sudo mv kustomize /usr/local/bin/kustomize
 
     - name: Deploy Image to Kubernetes
-      if: $ {{ inputs.type == 'kubernetes' }}
+      if: ${{ inputs.type == 'kubernetes' }}
       shell: bash
       env:
         DOCKER_REGISTRY: "docker.pkg.github.com"
@@ -89,7 +88,7 @@ runs:
     ###### Nuget deployments ######
 
     - name: Deploy Nuget
-      if: $ {{ inputs.type == 'nuget' }}
+      if: ${{ inputs.type == 'nuget' }}
       shell: bash
       env:
         NUGET_REGISTRY: "nuget.pkg.github.com"

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -1,0 +1,112 @@
+name: "Deploy"
+description: "Create a GitHub deployments, attempts to deploy and update deployment status."
+
+inputs:
+  environment:
+    description: "The environment targeted for the deployment"
+    required: true
+  type:
+    description: "The type of the deployment (ex: kubernetes, nuget, amplify, etc.)"
+    required: true
+  runner-name:
+    description: "The name of the runner used to perform the deployment"
+    required: true
+  tag:
+    description: "The version tag associated with the deployment"
+    required: true
+  artifact-name:
+    description: "Name of the artifact being deployed, it can be a docker image, a nuget package, etc."
+    required: true
+  service:
+    description: "Name of the service being deployed"
+
+runs:
+
+  using: composite
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check inputs
+      shell: bash
+      run: |
+        if [[ "${{ inputs.environment }}" != "production" 
+          && "${{ inputs.environment }}" != "stage" 
+          && "${{ inputs.environment }}" != "development" ]]; then
+            echo "Unsupported environment: ${{ inputs.environment }}"
+          exit 1
+        fi
+        if [[ "${{ inputs.type }}" != "kubernetes" 
+          && "${{ inputs.type }}" != "nuget" ]]; then
+          echo "Unsupported deployment type: ${{ inputs.environment }}"
+          exit 1
+        fi
+
+    - name: Create GitHub deployment
+      uses: chrnorm/deployment-action@v2
+      id: create-deployment
+      with:
+        token: '${{ github.token }}'
+        environment: ${{inputs.environment}}
+        payload: |
+          '{ 
+                "artifactName" : "${{ inputs.artifact-name }}",
+                "deploymentType" : "${{ inputs.type }}", 
+                "service" : "${{ inputs.service }}",
+                "tag" : "${{ inputs.tag }}"
+            }'
+
+    ###### Deployment types switch ######
+
+    ###### Kubernetes deployments ######
+
+      
+    - name: Install Kubernetes & Kustomize
+      #Since github runners working in Docker-in-Docker mode we need this workaround
+      if: $ {{ inputs.type == 'kubernetes' }}
+      shell: bash
+      run: |
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        sudo mv kustomize /usr/local/bin/kustomize
+
+    - name: Deploy Image to Kubernetes
+      if: $ {{ inputs.type == 'kubernetes' }}
+      shell: bash
+      env:
+        DOCKER_REGISTRY: "docker.pkg.github.com"
+      run: |
+        echo "deploying ${{ inputs.service }}"
+        echo "cd deployment/${{inputs.service}}/overlays/${{inputs.environment}}/""
+        echo "kustomize edit set image ${{inputs.service}}=$DOCKER_REGISTRY/$GITHUB_REPOSITORY/${{inputs.artifact-name}}:${{inputs.tag}}"
+        echo "kustomize build . | kubectl apply --validate=false -f -""
+
+    ###### Nuget deployments ######
+
+    - name: Deploy Nuget
+      if: $ {{ inputs.type == 'nuget' }}
+      shell: bash
+      env:
+        NUGET_REGISTRY: "nuget.pkg.github.com"
+      run: |
+        echo "pushing ${{ inputs.artifact-name }} to $NUGET_REGISTRY"
+
+    ###### End of Deployment types switch ######
+
+    - name: Update GitHub deployment status (success)
+      if: success()
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: '${{ github.token }}'
+        state: 'success'
+        deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
+
+    - name: Update GitHub deployment status (failure)
+      if: failure()
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: '${{ github.token }}'
+        state: 'failure'
+        deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -25,9 +25,12 @@ inputs:
 
 runs:
 
-  using: "composite"
+  using: composite
 
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Check inputs
       shell: bash
       run: |
@@ -47,8 +50,8 @@ runs:
       uses: chrnorm/deployment-action@v2
       id: create-deployment
       with:
-        token: '${{ github.token }}'
-        environment: ${{ inputs.environment }}
+        token: '${{ inputs.githubToken }}'
+        environment: ${{ inputs.environment}}
         payload: |
           '{ 
                 "artifactName" : "${{ inputs.artifact-name }}",
@@ -98,7 +101,7 @@ runs:
       if: success()
       uses: chrnorm/deployment-status@v2
       with:
-        token: '${{ github.token }}'
+        token: '${{ inputs.githubToken }}'
         state: 'success'
         deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}
 
@@ -106,6 +109,6 @@ runs:
       if: failure()
       uses: chrnorm/deployment-status@v2
       with:
-        token: '${{ github.token }}'
+        token: '${{ inputs.githubToken }}'
         state: 'failure'
         deployment-id: ${{ steps.create-deployment.outputs.deployment_id }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -28,9 +28,6 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
     - name: Check inputs
       shell: bash
       run: |


### PR DESCRIPTION
The action can be tested from the repo `github-actions-tester`
See https://github.com/trakx/github-actions-tester/actions for examples

In order to create a deployment and see it in JIRA, we need to make sure that the branch contains the reference of the issue and that it gets through a workflow that calls the new `deploy` actions created here.
This action should be improved, but I think this is enough to prove it can work.

We have many repeated deploy.template.yml files in each repo, which we should factor, and I hope this deployment can help.

We can talk about this in https://trakx.atlassian.net/wiki/spaces/Gatherings/pages/172720135/2023-06-21+Improvements+suggestions and decide if we want to change all the deploys use a common action instead
