### PR TITLE
Improved comments regarding dotnet container support

### DIFF
--- a/.github/workflows/shared-build-deploy-container.yml
+++ b/.github/workflows/shared-build-deploy-container.yml
@@ -1,5 +1,5 @@
 name: "Build, Push and Deploy a container image to Kubernetes"
-# Requires Microsoft.NET.Build.Containers package installed and a deployment folder to be present in the repository.
+# Requires `csproj` file contains `<EnableSdkContainerSupport>true</EnableSdkContainerSupport>` tag and a deployment folder to be present in the repository.
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Github action that bumps semver version and adds extended information to it
 
 ### build-push-container
 Builds and push a container image to the registry (Docker by default).
-Requires Microsoft.NET.Build.Containers package installed.
+Requires `csproj` file contains `<EnableSdkContainerSupport>true</EnableSdkContainerSupport>` tag.
 
 ### dependabot-automerge
 Call this on `pull_request` target events, give it pull request and content write privileges.

--- a/build-push-container/action.yml
+++ b/build-push-container/action.yml
@@ -1,5 +1,5 @@
 name: "Build and push container image"
-description: "Builds a docker image and pushes it to the github registry, Outputs the generated container image version. Requires Microsoft.NET.Build.Containers package installed."
+description: "Builds a docker image and pushes it to the github registry, Outputs the generated container image version."
 
 inputs:
   githubToken:


### PR DESCRIPTION
Yes, it's true. You don't need to install `Microsoft.NET.Build.Containers` package anymore.
Just need to add the `<EnableSdkContainerSupport>true</EnableSdkContainerSupport>` tag in the `csproj` file and that's it!
This is valid since .NET 7.0.200.