### PR TITLE
Made runnerName and environment inputs optional in shared-build-deploy-container (TKX-968)

### DIFF
--- a/.github/workflows/shared-build-deploy-container.yml
+++ b/.github/workflows/shared-build-deploy-container.yml
@@ -11,10 +11,6 @@ on:
         description: "Personal access token used to access the github private nuget source."
         required: true
     inputs:
-      runnerName:
-        description: "Name of the runner to use."
-        required: true
-        type: string
       projectFolder:
         description: "Folder containing the project to build."
         required: true
@@ -26,19 +22,26 @@ on:
       serviceName:
         required: true
         type: string
+      runnerName:
+        description: "Name of the runner to use."
+        required: false
+        type: string
+        default: ''
       environment:
         description: "Environment to deploy to (dev | staging | production)."
-        required: true
+        required: false
         type: string
+        default: ''
       containerPublishType:
         description: "Type of container publish (api | worker)."
-        required: true
+        required: false
         type: string
+        default: 'api'
       imageTagPrefix:
         description: "Prefix of the docker image tag. If not provided, will be generated based on the environment."
         required: false
         type: string
-        default: ""
+        default: ''
       dotnetVersion:
         description: "Version of dotnet to use. Default is v7.x."
         required: false
@@ -56,9 +59,35 @@ on:
         default: "master"
 
 jobs:
+  pick-runner:
+    name: "Pick the runner to use"
+    runs-on: ubuntu-latest
+    outputs:
+      runnerName: ${{ steps.pick-runner-step.outputs.runnerName }}
+    steps:
+      - name: Set variable RUNNER_NAME and DEPLOYMENT_ENVIRONMENT base on branch name
+        id: pick-runner-step
+        shell: bash
+        run: |
+          RUNNER_NAME="${{ inputs.runnerName }}"
+
+          if [[ -z "$RUNNER_NAME" ]]; then
+            if [[ "${{ github.ref }}" == "refs/heads/prod" || "${{ github.ref }}" == "refs/heads/master" ]]; then
+                RUNNER_NAME="prod-trakx-runner"
+            elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+                RUNNER_NAME="stage-trakx-runner"
+            else
+                RUNNER_NAME="dev-trakx-runner"
+            fi
+          fi
+
+          echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
+          echo "runnerName=$RUNNER_NAME" >> $GITHUB_OUTPUT
+
   build-push-container:
     name: "Build and push container image"
-    runs-on: ${{ inputs.runnerName }}
+    needs: pick-runner
+    runs-on: ${{ needs.pick-runner.outputs.runnerName }}
     steps:
       - name: Checkout calling repo
         uses: actions/checkout@v3
@@ -74,14 +103,30 @@ jobs:
         id: last-commit-sha
         uses: ./github-actions/get-last-commit
 
+      - name: Set variable DEPLOYMENT_ENVIRONMENT
+        shell: bash
+        run: |
+          DEPLOYMENT_ENVIRONMENT="${{ inputs.environment }}"
+          if [[ -z "$DEPLOYMENT_ENVIRONMENT" ]]; then
+            if [[ "${{ github.ref }}" == "refs/heads/prod" || "${{ github.ref }}" == "refs/heads/master" ]]; then
+                DEPLOYMENT_ENVIRONMENT="production"
+            elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+                DEPLOYMENT_ENVIRONMENT="staging"
+            else
+                DEPLOYMENT_ENVIRONMENT="development"
+            fi
+          fi
+          echo "Deploying to environment: $DEPLOYMENT_ENVIRONMENT"
+          echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_ENV
+
       - name: Set variable CONTAINER_IMAGE_TAG_PREFIX
         shell: bash
         run: |
-          IMAGE_TAG="${{inputs.imageTagPrefix}}"
+          IMAGE_TAG="${{ inputs.imageTagPrefix }}"
           if [[ -z "$IMAGE_TAG" ]]; then
-            if [[ "${{inputs.environment}}" == "production" ]]; then
+            if [[ "${{ env.DEPLOYMENT_ENVIRONMENT }}" == "production" ]]; then
                 IMAGE_TAG="prod"
-            elif [[ "${{inputs.environment}}" == "staging" ]]; then
+            elif [[ "${{ env.DEPLOYMENT_ENVIRONMENT }}" == "staging" ]]; then
                 IMAGE_TAG="stage"
             else
                 IMAGE_TAG="dev"
@@ -95,22 +140,22 @@ jobs:
         uses: ./github-actions/build-push-container
         with:
           githubToken: ${{ secrets.TRAKX_GITHUB_TOKEN }}
-          packageReadonlyPat: ${{secrets.TRAKX_BOT_READONLY_PAT}}
+          packageReadonlyPat: ${{ secrets.TRAKX_BOT_READONLY_PAT }}
           projectFolder: ${{ inputs.projectFolder }}
           imageName: ${{ inputs.imageName }}
           imageTagPrefix: ${{ env.CONTAINER_IMAGE_TAG_PREFIX }}
           containerPublishType: ${{ inputs.containerPublishType }}
           dotnetVersion: ${{ inputs.dotnetVersion }}
           dockerRegistry: ${{ inputs.dockerRegistry }}
-          imageTagSuffix: ${{steps.last-commit-sha.outputs.lastCommitSha}}
+          imageTagSuffix: ${{ steps.last-commit-sha.outputs.lastCommitSha }}
           doCheckout: false
     outputs:
       tag: ${{ steps.build-push-container-step.outputs.tag }}
 
   deploy-kubernetes:
     name: "Deploy container image to Kubernetes"
-    runs-on: ${{ inputs.runnerName }}
-    needs: build-push-container
+    needs: [ pick-runner, build-push-container ]
+    runs-on: ${{ needs.pick-runner.outputs.runnerName }}
     if: |
       always() &&
         (needs.build-push-container.result == 'success' || (needs.build-push-container.result == 'skipped'
@@ -132,8 +177,8 @@ jobs:
         uses: ./github-actions/deploy
         with:
           githubToken: ${{ secrets.TRAKX_GITHUB_TOKEN }}
-          environment: ${{inputs.environment}}
-          tag: ${{needs.build-push-container.outputs.tag}}
+          environment: ${{ env.DEPLOYMENT_ENVIRONMENT }}
+          tag: ${{ needs.build-push-container.outputs.tag }}
           service: ${{ inputs.serviceName }}
           artifact-name: ${{ inputs.imageName }}
           serviceRegistry: ${{ inputs.dockerRegistry }}

--- a/.github/workflows/shared-build-deploy-container.yml
+++ b/.github/workflows/shared-build-deploy-container.yml
@@ -23,17 +23,17 @@ on:
         required: true
         type: string
       runnerName:
-        description: "Name of the runner to use."
+        description: "Name of the runner to use. If not provided, will be generated based on the branch name."
         required: false
         type: string
         default: ''
       environment:
-        description: "Environment to deploy to (dev | staging | production)."
+        description: "Environment to deploy to (dev | staging | production). If not provided, will be generated based on the branch name."
         required: false
         type: string
         default: ''
       containerPublishType:
-        description: "Type of container publish (api | worker)."
+        description: "Type of container publish (api | worker). Default is api."
         required: false
         type: string
         default: 'api'
@@ -48,7 +48,7 @@ on:
         type: string
         default: "7.x"
       dockerRegistry:
-        description: "Docker registry to push the image to."
+        description: "Docker registry to push the image to. Default is docker.pkg.github.com."
         required: false
         type: string
         default: "docker.pkg.github.com"
@@ -65,7 +65,7 @@ jobs:
     outputs:
       runnerName: ${{ steps.pick-runner-step.outputs.runnerName }}
     steps:
-      - name: Set variable RUNNER_NAME and DEPLOYMENT_ENVIRONMENT base on branch name
+      - name: Set variable RUNNER_NAME based on branch name
         id: pick-runner-step
         shell: bash
         run: |
@@ -80,13 +80,37 @@ jobs:
                 RUNNER_NAME="dev-trakx-runner"
             fi
           fi
-
+          echo "Using runner: $RUNNER_NAME"
           echo "RUNNER_NAME=$RUNNER_NAME" >> $GITHUB_ENV
           echo "runnerName=$RUNNER_NAME" >> $GITHUB_OUTPUT
 
+  pick-environment:
+    name: "Pick the environment to deploy"
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.pick-environment-step.outputs.environment }}
+    steps:
+      - name: Set variable DEPLOYMENT_ENVIRONMENT based on branch name
+        id: pick-environment-step
+        shell: bash
+        run: |
+          DEPLOYMENT_ENVIRONMENT="${{ inputs.environment }}"
+          if [[ -z "$DEPLOYMENT_ENVIRONMENT" ]]; then
+            if [[ "${{ github.ref }}" == "refs/heads/prod" || "${{ github.ref }}" == "refs/heads/master" ]]; then
+                DEPLOYMENT_ENVIRONMENT="production"
+            elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
+                DEPLOYMENT_ENVIRONMENT="staging"
+            else
+                DEPLOYMENT_ENVIRONMENT="development"
+            fi
+          fi
+          echo "Deploying to environment: $DEPLOYMENT_ENVIRONMENT"
+          echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_ENV
+          echo "environment=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_OUTPUT
+
   build-push-container:
     name: "Build and push container image"
-    needs: pick-runner
+    needs: [ pick-runner, pick-environment ]
     runs-on: ${{ needs.pick-runner.outputs.runnerName }}
     steps:
       - name: Checkout calling repo
@@ -103,30 +127,14 @@ jobs:
         id: last-commit-sha
         uses: ./github-actions/get-last-commit
 
-      - name: Set variable DEPLOYMENT_ENVIRONMENT
-        shell: bash
-        run: |
-          DEPLOYMENT_ENVIRONMENT="${{ inputs.environment }}"
-          if [[ -z "$DEPLOYMENT_ENVIRONMENT" ]]; then
-            if [[ "${{ github.ref }}" == "refs/heads/prod" || "${{ github.ref }}" == "refs/heads/master" ]]; then
-                DEPLOYMENT_ENVIRONMENT="production"
-            elif [[ "${{ github.ref }}" == "refs/heads/stage" ]]; then
-                DEPLOYMENT_ENVIRONMENT="staging"
-            else
-                DEPLOYMENT_ENVIRONMENT="development"
-            fi
-          fi
-          echo "Deploying to environment: $DEPLOYMENT_ENVIRONMENT"
-          echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_ENV
-
       - name: Set variable CONTAINER_IMAGE_TAG_PREFIX
         shell: bash
         run: |
           IMAGE_TAG="${{ inputs.imageTagPrefix }}"
           if [[ -z "$IMAGE_TAG" ]]; then
-            if [[ "${{ env.DEPLOYMENT_ENVIRONMENT }}" == "production" ]]; then
+            if [[ "${{ needs.pick-environment.outputs.environment }}" == "production" ]]; then
                 IMAGE_TAG="prod"
-            elif [[ "${{ env.DEPLOYMENT_ENVIRONMENT }}" == "staging" ]]; then
+            elif [[ "${{ needs.pick-environment.outputs.environment }}" == "staging" ]]; then
                 IMAGE_TAG="stage"
             else
                 IMAGE_TAG="dev"
@@ -154,7 +162,7 @@ jobs:
 
   deploy-kubernetes:
     name: "Deploy container image to Kubernetes"
-    needs: [ pick-runner, build-push-container ]
+    needs: [ pick-runner, pick-environment, build-push-container ]
     runs-on: ${{ needs.pick-runner.outputs.runnerName }}
     if: |
       always() &&
@@ -177,7 +185,7 @@ jobs:
         uses: ./github-actions/deploy
         with:
           githubToken: ${{ secrets.TRAKX_GITHUB_TOKEN }}
-          environment: ${{ env.DEPLOYMENT_ENVIRONMENT }}
+          environment: ${{ needs.pick-environment.outputs.environment }}
           tag: ${{ needs.build-push-container.outputs.tag }}
           service: ${{ inputs.serviceName }}
           artifact-name: ${{ inputs.imageName }}

--- a/.github/workflows/shared-build-deploy-container.yml
+++ b/.github/workflows/shared-build-deploy-container.yml
@@ -108,9 +108,24 @@ jobs:
           echo "DEPLOYMENT_ENVIRONMENT=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_ENV
           echo "environment=$DEPLOYMENT_ENVIRONMENT" >> $GITHUB_OUTPUT
 
+  validate-event:
+    name: "Validate if event is allowed for the given environment"
+    needs: [ pick-environment ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block workflow_dispatch for staging and production
+        shell: bash
+        run: |
+          if [[ "${{ needs.pick-environment.outputs.environment }}" == "production" || "${{ needs.pick-environment.outputs.environment }}" == "staging" ]]; then
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              echo "Event workflow_dispatch is not allowed for environment ${{ needs.pick-environment.outputs.environment }}."
+              exit 1
+            fi
+          fi
+
   build-push-container:
     name: "Build and push container image"
-    needs: [ pick-runner, pick-environment ]
+    needs: [ pick-runner, pick-environment, validate-event ]
     runs-on: ${{ needs.pick-runner.outputs.runnerName }}
     steps:
       - name: Checkout calling repo


### PR DESCRIPTION
Now `containerPublishType`, `runnerName` and `environment` are optional inputs.
The `containerPublishType` input will be `api` by default.

If both `runnerName` and `environment` inputs aren't send, they will be generated based on the branch name.
If branch is `prod` or `master`, will use production environment and runner.
If branch is `stage`, will use staging environment and runner.
Otherwise, will always use development environment and runner.

Also added a protection to the workflow to avoid `workflow_dispatch` events to staging and production environments.

With these changes, it will be possible to use a single file to run all the deployment pipeline 🤩 Below an example of that file in `user-management` (deploy.yml file content):

![image](https://github.com/trakx/github-actions/assets/6867927/b8d6cbba-dedb-4868-bbec-1b27e10d81e0)