### PR TITLE
Allow to input dotnet version in publish nuget and test dotnet actions

### DIFF
--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -20,7 +20,12 @@ inputs:
     description: "Run actions from this ref. Default is master."
     required: false
     default: "master"
-    
+  dotnetVersion:
+    description: "Version of dotnet to use. Default is v7.x."
+    required: false
+    type: string
+    default: "7.x"
+
 runs:
   using: "composite"
   steps:
@@ -53,10 +58,10 @@ runs:
         semverIncrementLevel: ${{ inputs.semverIncrementLevel }}
         preRelease: ${{ inputs.debuggable }}
 
-    - name: Setup .NET Core
+    - name: .NET Install
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: ${{ inputs.dotnetVersion }}
 
     - name: Add github nuget source
       shell: bash

--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "Region on which to access the AWS environment."
     required: false
     default: "eu-west-3"
+  dotnetVersion:
+    description: "Version of dotnet to use. Default is v7.x."
+    required: false
+    type: string
+    default: "7.x"
 
 runs:
   using: "composite"
@@ -30,7 +35,7 @@ runs:
         DOTNET_INSTALL_DIR: "./.dotnet"  # Required by the runner to install dotnet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: ${{ inputs.dotnetVersion }}
 
     - name: Add Trakx github nuget source
       shell: bash


### PR DESCRIPTION
The default dotnet version is 7.x
However, this will be ready to allow us to upgrade a dotnet version without releasing a new action version.

These changes were already tested in `trakx/user-management` repository.