### PR TITLE
Feature/container build workers

### DIFF
--- a/build-push-container/action.yml
+++ b/build-push-container/action.yml
@@ -116,6 +116,13 @@ runs:
       shell: bash
       run: echo "IMAGEPATH=${{inputs.dockerRegistry}}/$GITHUB_REPOSITORY/${{inputs.imageName}}" >> $GITHUB_ENV
 
+    - name: Install Microsoft.NET.Build.Containers (Worker)
+      if: ${{inputs.containerPublishType == 'worker'}}
+      shell: bash
+      working-directory: ${{env.WORKDIR}}
+      run: >
+        dotnet add package Microsoft.NET.Build.Containers --no-restore
+
     - name: .NET Restore
       shell: bash
       working-directory: ${{env.WORKDIR}}
@@ -125,10 +132,10 @@ runs:
       shell: bash
       run: dotnet nuget remove source "github"
 
-    - name: .NET Build
-      shell: bash
-      working-directory: ${{env.WORKDIR}}
-      run: dotnet build
+    # - name: .NET Build
+    #   shell: bash
+    #   working-directory: ${{env.WORKDIR}}
+    #   run: dotnet build
 
     # https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container
     - name: .NET Publish Container (API)
@@ -141,13 +148,6 @@ runs:
         -p:ContainerImageName=${{inputs.imageName}}
         -p:ContainerImageTag=${{env.tag}}
         -c Release
-
-    - name: Install Microsoft.NET.Build.Containers (Worker)
-      if: ${{inputs.containerPublishType == 'worker'}}
-      shell: bash
-      working-directory: ${{env.WORKDIR}}
-      run: >
-        dotnet add package Microsoft.NET.Build.Containers
 
     - name: .NET Publish Container (Worker)
       if: ${{inputs.containerPublishType == 'worker'}}

--- a/build-push-container/action.yml
+++ b/build-push-container/action.yml
@@ -142,6 +142,13 @@ runs:
         -p:ContainerImageTag=${{env.tag}}
         -c Release
 
+    - name: Install Microsoft.NET.Build.Containers (Worker)
+      if: ${{inputs.containerPublishType == 'worker'}}
+      shell: bash
+      working-directory: ${{env.WORKDIR}}
+      run: >
+        dotnet add package Microsoft.NET.Build.Container
+
     - name: .NET Publish Container (Worker)
       if: ${{inputs.containerPublishType == 'worker'}}
       shell: bash

--- a/build-push-container/action.yml
+++ b/build-push-container/action.yml
@@ -132,11 +132,6 @@ runs:
       shell: bash
       run: dotnet nuget remove source "github"
 
-    # - name: .NET Build
-    #   shell: bash
-    #   working-directory: ${{env.WORKDIR}}
-    #   run: dotnet build
-
     # https://learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container
     - name: .NET Publish Container (API)
       if: ${{inputs.containerPublishType == 'api'}}

--- a/build-push-container/action.yml
+++ b/build-push-container/action.yml
@@ -147,7 +147,7 @@ runs:
       shell: bash
       working-directory: ${{env.WORKDIR}}
       run: >
-        dotnet add package Microsoft.NET.Build.Container
+        dotnet add package Microsoft.NET.Build.Containers
 
     - name: .NET Publish Container (Worker)
       if: ${{inputs.containerPublishType == 'worker'}}


### PR DESCRIPTION
For workers, we need to have `Microsoft.NET.Build.Containers` package installed yet. 😢 
Also removed the `dotnet build` step since it is useless because `dotnet publish` runs the build in the correct compilation mode.

Run example with this version: https://github.com/trakx/market-data/actions/runs/5456325052/jobs/9928991162

Some references:
- https://github.com/dotnet/sdk/pull/32422
- https://github.com/dotnet/sdk-container-builds/issues/402