### PR TITLE
Fix checkout logic in shared actions

### DIFF
--- a/build-push-container-image/action.yml
+++ b/build-push-container-image/action.yml
@@ -1,4 +1,4 @@
-name: "Build and push container image"
+name: "Build and push dotnet container image"
 description: "Builds a docker image and pushes it to the github registry. Outputs the generated container image version."
 
 inputs:
@@ -57,7 +57,6 @@ runs:
         ref: ${{ inputs.actionsRepoRef }}
 
     - name: Restore and cache private nuget packages
-      if: ${{ contains(fromJson(inputs.privateRepoTypes), 'nuget') }}
       uses: ./github-actions-build-push-container-image/restore-dotnet
       with:
         dotnetVersion: ${{inputs.dotnetVersion}}

--- a/code-quality/action.yml
+++ b/code-quality/action.yml
@@ -22,6 +22,10 @@ runs:
   using: composite
 
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Checkout trakx/github-actions repo
       uses: actions/checkout@v4
@@ -36,7 +40,6 @@ runs:
       with:
         dotnetVersion: ${{inputs.dotnetVersion}}
         packageReadonlyPat: ${{inputs.packageReadonlyPat}}
-        fetchDepth: 0
 
     # this is to resolve the issue of analysing private package sources
     # https://www.jetbrains.com/help/qodana/qodana-dotnet-docker-readme.html#Inspect+using+private+nuget+repositories

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "Level of the semver (major.minor.patch) to be increased to get the new package version."
     required: false
     default: "patch"
-  actionRef:
+  actionsRepoRef:
     description: "Run actions from this ref. Default is master."
     required: false
     default: "master"
@@ -45,7 +45,7 @@ runs:
       with:
         repository: trakx/github-actions
         path: ./github-actions-publish-nuget
-        ref: ${{ inputs.actionRef }}
+        ref: ${{ inputs.actionsRepoRef }}
 
     - name: Restore and cache private nuget packages
       uses: ./github-actions-publish-nuget/restore-dotnet

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -56,12 +56,6 @@ runs:
         dotnetVersion: ${{inputs.dotnetVersion}}
         packageReadonlyPat: ${{inputs.packageReadonlyPat}}
 
-      #temp debug help
-    - name: Show content of local folders
-      shell: bash
-      run: |
-        find ./.. | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"
-
     - name: Bump version
       id: bumpVersion
       uses: ./github-actions-publish-nuget/get-tag

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -48,7 +48,6 @@ runs:
         ref: ${{ inputs.actionRef }}
 
     - name: Restore and cache private nuget packages
-      if: ${{ contains(fromJson(inputs.privateRepoTypes), 'nuget') }}
       uses: ./github-actions-publish-nuget/restore-dotnet
       with:
         dotnetVersion: ${{inputs.dotnetVersion}}

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -40,6 +40,9 @@ runs:
         echo "compilationMode=$COMP_MODE" >> $GITHUB_OUTPUT
         echo "compilation mode set to $COMP_MODE"
 
+    - name: Checkout
+      uses: actions/checkout@v4
+        
     - name: Checkout actions repo
       uses: actions/checkout@v4
       with:

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -53,6 +53,12 @@ runs:
         dotnetVersion: ${{inputs.dotnetVersion}}
         packageReadonlyPat: ${{inputs.packageReadonlyPat}}
 
+      #temp debug help
+    - name: Show content of local folders
+      shell: bash
+      run: |
+        find ./.. | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"
+
     - name: Bump version
       id: bumpVersion
       uses: ./github-actions-publish-nuget/get-tag

--- a/restore-dotnet/action.yml
+++ b/restore-dotnet/action.yml
@@ -9,18 +9,10 @@ inputs:
     description: "Version of dotnet to use. Default is v7.x."
     required: false
     default: "7.x"
-  fetchDepth:
-    description: "Number of commits to fetch. 0 indicates all history for all branches and tags. Default 1."
-    required: true
-    default: "1"
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: ${{inputs.fetchDepth}}
 
     - name: .NET Install
       env:

--- a/test-dotnet/action.yml
+++ b/test-dotnet/action.yml
@@ -30,7 +30,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-  
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{inputs.fetchDepth}}
+
     - name: Checkout trakx/github-actions repo
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Only the calling action should be checking out the repo, otherwise checkouts get deleted as we exit the called sub-workflow