### PR TITLE
Fix warning about obsolete parameter

### DIFF
--- a/build-push-container-image/action.yml
+++ b/build-push-container-image/action.yml
@@ -114,7 +114,7 @@ runs:
       run: >
         dotnet publish --os linux --arch x64
         -p:PublishProfile=DefaultContainer
-        -p:ContainerImageName=${{inputs.imageName}}
+        -p:ContainerRepository=${{inputs.imageName}}
         -p:ContainerImageTag=${{env.tag}}
         -c Release
 


### PR DESCRIPTION
Fixing this warning:
<img width="950" alt="image" src="https://github.com/trakx/github-actions/assets/6867927/99685e62-b79c-4d52-8383-7c8498b959aa">
