### PR TITLE
Dev ➡️  Master

### DIFF
--- a/restore-dotnet/action.yml
+++ b/restore-dotnet/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('packages.lock.json', '*/packages.lock.json') }}
         restore-keys: ${{ runner.os }}-nuget-
 
     - name: .NET Restore packages


### PR DESCRIPTION
Bump the `chrnorm` packages as the previous versions were set to Node 16 which is now deprecated.
Full context here: https://github.com/trakx/github-actions/pull/92