### PR TITLE
Change tag to `buildNumber-branchName-commitHash`

### DIFF
--- a/get-tag/action.yml
+++ b/get-tag/action.yml
@@ -79,7 +79,7 @@ runs:
         else
             BRANCH_NAME=${GITHUB_REF##*/}
             BRANCH_NAME=${BRANCH_NAME//[^0-9a-zA-Z]/-}
-            PRODUCT_VERSION=${BRANCH_NAME}-${{github.run_number}}-${{steps.shortHash.outputs.shortHash}}
+            PRODUCT_VERSION=${{github.run_number}}-${BRANCH_NAME}-${{steps.shortHash.outputs.shortHash}}
             FULL_VERSION=${SUBSTRING_LEFT_OF_DASH}-${PRODUCT_VERSION}
         fi
         echo "assemblyVersion=$SUBSTRING_LEFT_OF_DASH" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This change aims to fix this issue (the topmost item is not the most recent version):


![image](https://github.com/user-attachments/assets/0a5ee315-4c0d-4b4a-9937-2569748fd6c4)
