### PR TITLE
Delete nuget version shared action

### DIFF
--- a/delete-nuget-version/action.yml
+++ b/delete-nuget-version/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Delete package version
       uses: actions/delete-package-versions@v5
       with:
-        package-name: ${{inputs.githubToken}}
+        package-name: ${{inputs.package-name}}
         package-type: "nuget"
-        min-versions-to-keep: ${{inputs.num-old-pre-release-versions-to-keep}}
+        num-old-pre-release-versions-to-keep: ${{inputs.num-old-pre-release-versions-to-keep}}
         delete-only-pre-release-versions: "true"

--- a/delete-nuget-version/action.yml
+++ b/delete-nuget-version/action.yml
@@ -23,5 +23,5 @@ runs:
       with:
         package-name: ${{inputs.package-name}}
         package-type: "nuget"
-        num-old-pre-release-versions-to-keep: ${{inputs.num-old-pre-release-versions-to-keep}}
+        min-versions-to-keep: ${{inputs.num-old-pre-release-versions-to-keep}}
         delete-only-pre-release-versions: "true"

--- a/delete-nuget-version/action.yml
+++ b/delete-nuget-version/action.yml
@@ -18,6 +18,7 @@ runs:
       run: sleep 5s
       shell: bash
 
+    # Delete package version using the delete-package-versions external action
     - name: Delete package version
       uses: actions/delete-package-versions@v5
       with:

--- a/delete-nuget-version/action.yml
+++ b/delete-nuget-version/action.yml
@@ -1,0 +1,27 @@
+name: "Delete pre-release versions from a nuget package"
+description: "Delete pre-release versions from a nuget package."
+
+inputs:
+  package-name:
+    description: "The package name"
+    required: true
+
+  num-old-pre-release-versions-to-keep:
+    description: 'The number of old pre-release versions to keep starting from the newest version'
+    default: '5'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Wait to start (try to avoid rate limiting)
+      run: sleep 5s
+      shell: bash
+
+    - name: Delete package version
+      uses: actions/delete-package-versions@v5
+      with:
+        package-name: ${{inputs.githubToken}}
+        package-type: "nuget"
+        min-versions-to-keep: ${{inputs.num-old-pre-release-versions-to-keep}}
+        delete-only-pre-release-versions: "true"


### PR DESCRIPTION
Action to delete nuget package versions.
It will delete only pre-release versions and, by default, will keep the latest 5 pre-release versions.

The delay added is not 100% reliable, since github api returns how much time we should wait to make api calls again. To implement such feature, would need to use a javascript script or something to handle it properly. So this delay avoids that issue.

[Example of usage here](https://github.com/trakx/common/blob/chore/new-delete-pkg/.github/workflows/delete.packages.yml).

🚨 **This action does not remove tags**. To delete tags, please check this PR: https://github.com/trakx/github-actions/pull/108